### PR TITLE
Introduced cli support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 lib
 node_modules
 vendor
-bin
 log
 data
 tmp

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,13 @@ publish: clean build
 serve:
 	$(BABEL_NODE) server.js
 
-dist/index.js: src/* index.js express.js package.json
+dist/index.js: src/* index.js express.js package.json bin/*
 	$(BABEL) src/ --out-dir dist/src --copy-files
 	$(BABEL) index.js --out-file dist/index.js
 	$(BABEL) express.js --out-file dist/express.js
+	mkdir -p dist/bin
+	$(BABEL) bin/nomplate --out-file dist/bin/nomplate
+	chmod 755 dist/bin/nomplate
 	cp package.json dist/package.json
 
 dist/nomplate.min.js:

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "nomplate",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Nomplate: Node template engine",
   "main": "nomplate.js",
   "directories": {
+    "bin": "./bin",
     "src": "./src"
   },
   "files": [

--- a/test/fixtures/view.js
+++ b/test/fixtures/view.js
@@ -1,0 +1,11 @@
+import {dom} from '../../';
+
+function view(options) {
+  return dom.div(() => {
+    dom.h1('hello world: ' + options.foo);
+    dom.div('from inside');
+  });
+}
+
+export default view;
+


### PR DESCRIPTION
This is a rough cut of a CLI tool that allows you to evaluate and render template files to the terminal or to disk.

The usage is something like:
```bash
nomplate --output my_template.html --pretty --customArg 1234 --otherArg otherValue ./my_template.js
```
This example will call the template function that is exported by my_template.js with a hash that looks like, `{customArg: 1234, otherArg: 'otherValue'}`.

Boolean and numeric values will be JavaScript native, strings will be forwarded as-is.

The option `--pretty` will pretty print the output

The option `--output <FILE>` will drop the output to the provided file target, if this argument is not present, the text will be rendered to the console, but this may be interleaved with any console.log statements that your application emits.
