### PR TITLE
Fix legacy test to verify actual escape rules

### DIFF
--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -83,9 +83,9 @@ describe('Nomplate ElementBuilder', () => {
     assert.equal(script.attrs.src, '/abcd.js');
   });
 
-  it.skip('escapes markup', () => {
+  it('does not escape markup, unless rendered', () => {
     const div = builder('div', '<script>');
-    // assert.equal(div.textValue, '&lt;script&gt;');
+    assert.equal(div.textValue, '<script>');
   });
 
   it('collapses handler', () => {


### PR DESCRIPTION
HTML escape in client requires the document object for performance and therefore can only happen on render, not on creation.