### PR TITLE
Added validation to builder for onenter sugar

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -65,10 +65,14 @@ function processHandler(elem, handler) {
 }
 
 function processAttrs(attrs) {
-  if (attrs && attrs.className) {
-    /* eslint-disable no-param-reassign */
-    attrs.className = processClassName(attrs.className);
-    /* eslint-enable no-param-reassign */
+  if (attrs) {
+    if (attrs.className) {
+      /* eslint-disable no-param-reassign */
+      attrs.className = processClassName(attrs.className);
+      /* eslint-enable no-param-reassign */
+    } else if (attrs.onenter && attrs.onkeyup) {
+      throw new Error('onenter and onkeyup are mutually exclusive, consider adding a switch statement to your onkeyup handler for the enter case.');
+    }
   }
   return attrs;
 }

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -105,6 +105,13 @@ describe('Nomplate ElementBuilder', () => {
     assert.equal(ul.children[2].textContent, 'three');
   });
 
+  it('onenter and onkeyup are mutually exclusive', () => {
+    const keyHandler = sinon.spy();
+    assert.throws(() => {
+      dom.div({onenter: keyHandler, onkeyup: keyHandler});
+    }, /are mutually exclusive/);
+  });
+
   it('handles null attrs (though not recommended)', () => {
     const ul = builder('ul', null, () => {
       builder('li', null, 'one');

--- a/test/render_element_test.js
+++ b/test/render_element_test.js
@@ -74,28 +74,6 @@ describe('Nomplate renderElement', () => {
     assert.equal(clickHandler.callCount, 1);
   });
 
-  // TODO(lbayes): Subscriptions to onEnter and onKeyup are mutually exclusive!
-  it.skip('applies onenter and onkeyup', () => {
-    function getEventFor(keyCode) {
-      const event = document.createEvent('KeyboardEvent');
-      event.initKeyboardEvent('keyup', true, true, null, false, false, false, false, keyCode);
-      return event;
-    }
-
-    const keyHandler = sinon.spy();
-    const div = dom.div({onenter: keyHandler, onkeyup: keyHandler});
-    const element = renderElement(div, document);
-
-    element.dispatchEvent(getEventFor(12));
-    assert.equal(keyHandler.callCount, 1);
-    element.dispatchEvent(getEventFor(12));
-    assert.equal(keyHandler.callCount, 2);
-
-    // Trigger enter key
-    element.dispatchEvent(getEventFor(13));
-    assert.equal(keyHandler.callCount, 4, 'Should have called both handlers');
-  });
-
   it('removes handler', () => {
     const handler = sinon.spy();
     const div = dom.div({onclick: handler, onkeyup: handler, onkeydown: handler});


### PR DESCRIPTION
In the current implementation, we use element 'on' callbacks to apply event handlers. This is done because it allows us to unsubscribe from events without holding a reference to the original handler.

When someone uses the onenter (custom sugar) key, we transform that into an onkeyup under the covers. This makes it impossible to also subscribe to an onkeyup event on the same element. We could consider adding a more sophisticated event wrapper, but for now, it feels simpler to just disallow this case.

Please do let me know if this confusing bit of sugar bites you.
