### PR TITLE
Removed asynchrony in render and update cycles, added to onRender callbacks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nomplate",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "Nomplate: Node template engine",
   "main": "index.js",
   "repository": {

--- a/src/builder.js
+++ b/src/builder.js
@@ -39,8 +39,8 @@ function processClassName(value) {
   return value;
 }
 
-function getRenderScheduler(elem, handler) {
-  return function _getRenderScheduler(optCompleteHandler) {
+function getUpdateScheduler(elem, handler) {
+  return function _getUpdateScheduler(optCompleteHandler) {
     if (elem.onRender) {
       schedule(elem, () => {
         /* eslint-disable no-use-before-define */
@@ -57,7 +57,7 @@ function processHandler(elem, handler) {
     /* eslint-disable no-param-reassign */
     elem.hasUpdateableHandler = true;
     /* eslint-enable no-param-reassign */
-    handler(getRenderScheduler(elem, handler));
+    handler(getUpdateScheduler(elem, handler));
   } else {
     handler();
   }

--- a/src/render_element.js
+++ b/src/render_element.js
@@ -10,25 +10,19 @@ function getUpdateElement(nomElement, document, optDomElement) {
   return function _updateElement(builder, handler, optCompleteHandler) {
     const parentNode = optDomElement.parentNode;
     const newNomElement = builder(nomElement.nodeName, nomElement.attrs, handler);
-    localSetTimeout(() => {
-      const nullOrParentElement = parentNode ? null : optDomElement;
+    const nullOrParentElement = parentNode ? null : optDomElement;
 
-      /* eslint-disable no-use-before-define */
-      const newDomElement = renderElement(newNomElement, document, nullOrParentElement);
-      /* eslint-enable no-use-before-define */
+    /* eslint-disable no-use-before-define */
+    const newDomElement = renderElement(newNomElement, document, nullOrParentElement);
+    /* eslint-enable no-use-before-define */
 
-      localSetTimeout(() => {
-        if (parentNode) {
-          parentNode.replaceChild(newDomElement, optDomElement);
-        }
+    if (parentNode) {
+      parentNode.replaceChild(newDomElement, optDomElement);
+    }
 
-        if (optCompleteHandler && typeof optCompleteHandler === 'function') {
-          localSetTimeout(() => {
-            optCompleteHandler(newDomElement, newNomElement);
-          }, 0);
-        }
-      }, 0);
-    }, 0);
+    if (optCompleteHandler && typeof optCompleteHandler === 'function') {
+      optCompleteHandler(newDomElement, newNomElement);
+    }
   };
 }
 
@@ -52,9 +46,16 @@ function executeOperations(ops, nomElement, document, optDomElement) {
     return result;
   }, optDomElement);
 
-  trailingActions.forEach((action) => {
-    action();
-  });
+  // Any operation that returns a function (e.g., onRender ops) will have the
+  // returned handler executed in the next interval.
+  // This allows handlers like onRender to accept DOM elements and call methods
+  // (like focus()) after the elements have been attached to the document
+  // during and update() lifecycle.
+  localSetTimeout(() => {
+    trailingActions.forEach((action) => {
+      action();
+    });
+  }, 0);
 
   return root;
 }

--- a/test/render_element_test.js
+++ b/test/render_element_test.js
@@ -1,8 +1,8 @@
 const assert = require('chai').assert;
 const createWindow = require('../test_helper').createWindow;
 const dom = require('../').dom;
-const simulant = require('jsdom-simulant');
 const renderElement = require('../').renderElement;
+const simulant = require('jsdom-simulant');
 const sinon = require('sinon');
 const svg = require('../').svg;
 
@@ -331,7 +331,7 @@ describe('Nomplate renderElement', () => {
       assert.equal(element.outerHTML, '<div><svg><rect width="200" height="100"></rect></svg></div>');
     });
 
-    it('receives the real dom element on request', () => {
+    it('receives the real dom element on request', (done) => {
       const onRender = sinon.spy();
 
       const root = dom.div({id: 'abcd', onRender}, () => {
@@ -348,15 +348,47 @@ describe('Nomplate renderElement', () => {
       }
 
       renderElement(root, doc);
-      assert.equal(onRender.callCount, 5);
-      assert.equal(getCallArgument(0).id, 'abcd');
-      assert.equal(getCallArgument(1).id, 'efgh');
-      assert.equal(getCallArgument(2).id, 'ijkl');
-      assert.equal(getCallArgument(2).outerHTML, '<li id="ijkl">ijkl</li>');
-      assert.equal(getCallArgument(3).id, 'mnop');
-      assert.equal(getCallArgument(3).outerHTML, '<li id="mnop">mnop</li>');
-      assert.equal(getCallArgument(4).id, 'qrst');
-      assert.equal(getCallArgument(4).outerHTML, '<li id="qrst">qrst</li>');
+
+      setTimeout(() => {
+        try {
+          assert.equal(onRender.callCount, 5);
+          assert.equal(getCallArgument(0).id, 'abcd');
+          assert.equal(getCallArgument(1).id, 'efgh');
+          assert.equal(getCallArgument(2).id, 'ijkl');
+          assert.equal(getCallArgument(2).outerHTML, '<li id="ijkl">ijkl</li>');
+          assert.equal(getCallArgument(3).id, 'mnop');
+          assert.equal(getCallArgument(3).outerHTML, '<li id="mnop">mnop</li>');
+          assert.equal(getCallArgument(4).id, 'qrst');
+          assert.equal(getCallArgument(4).outerHTML, '<li id="qrst">qrst</li>');
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }, 0);
+
+    });
+
+    it.skip('receives onRender after being attached', () => {
+      // Return true if the provided element is attached to the stub document.
+      function elementIsAttached(element) {
+        if (element === doc) {
+          return true;
+        }
+        const parent = element.parentNode;
+        if (parent) {
+          return elementIsAttached(parent);
+        }
+        return false;
+      }
+
+      // Called onRender by nomplate.
+      function onRender(element) {
+        assert(elementIsAttached(element), 'onRender should be called after attachment to document');
+      }
+
+      const element = renderElement(dom.div({id: 'abcd', onRender: onRender}), doc);
+      doc.body.appendChild(element);
+      console.log('finished');
     });
 
     describe('deep mutations', () => {

--- a/test/scheduler_test.js
+++ b/test/scheduler_test.js
@@ -52,7 +52,7 @@ describe('Nomplate scheduler', () => {
     assert.equal(childRender.callCount, 0);
   });
 
-  it('skips deep children', () => {
+  it('skips children', () => {
     const root = new Element('aye');
     const rootRender = sinon.spy();
 


### PR DESCRIPTION
Removed nested asynchrony from update cycle so that updates now create elements, attach elements and notify the complete handler synchronously (after the next animationframe), where each of these actions was previously done in a separate interval.

Ensured that onRender attribute handlers are now called on the next interval after dom elements have been created. This provides opportunity for a second synchronous caller to attach elements to a document, which makes it possible for calls to focus() or other element queries to work as expected.