### PR TITLE
All onRender handlers should be called, even when one fails.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nomplate",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "Nomplate: Node template engine",
   "main": "index.js",
   "repository": {

--- a/src/operations.js
+++ b/src/operations.js
@@ -38,7 +38,13 @@ function enqueueOnRender(handler) {
     // If functions are returned, they will be added to the end of the
     // operation list and executed after the DOM tree has been constructed.
     return function _enqueueOnRenderInternal() {
-      handler(element);
+      // PERF(lbayes): try..catch blocks have notorious performance problems,
+      // investigate altarnative approaches.
+      try {
+        handler(element);
+      } catch (err) {
+        console.error(err);
+      }
     };
   };
 }

--- a/src/render_element.js
+++ b/src/render_element.js
@@ -52,6 +52,11 @@ function executeOperations(ops, nomElement, document, optDomElement) {
   // (like focus()) after the elements have been attached to the document
   // during and update() lifecycle.
   localSetTimeout(() => {
+    // NOTE(lbayes): This is now disconnected from the main request thread,
+    // exceptions may get swallowed. The implementation of enqueueOnRender
+    // does make an effort to continue after user-defined exceptions, so at
+    // least we should not see mysterious missed calls if a previous call
+    // fails.
     trailingActions.forEach((action) => {
       action();
     });

--- a/test/render_element_test.js
+++ b/test/render_element_test.js
@@ -331,6 +331,38 @@ describe('Nomplate renderElement', () => {
       assert.equal(element.outerHTML, '<div><svg><rect width="200" height="100"></rect></svg></div>');
     });
 
+    it('proceeds when onRender handlers fail', (done) => {
+      let message;
+
+      // Ensure we log the async error.
+      sinon.stub(console, 'error', (_message) => {
+        message =_message;
+      });
+
+      const one = () => { throw new Error('fake-error'); };
+      const two = sinon.spy();
+
+      const root = dom.div(() => {
+        dom.div({onRender: one});
+        dom.div({onRender: two});
+      });
+
+      renderElement(root, doc);
+
+      setTimeout(() => {
+        try {
+          assert.equal(two.callCount, 1);
+          assert.match(console.error.getCall(0).args[0], /fake-error/);
+          done();
+        } catch (err) {
+          done(err);
+        } finally {
+          // Ensure we clean up the console.error stub
+          console.error.restore();
+        }
+      }, 0);
+    });
+
     it('receives the real dom element on request', (done) => {
       const onRender = sinon.spy();
 


### PR DESCRIPTION
Fixes issue #54