### PR TITLE
Fixed #67 Ensure update complete handler is always called

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nomplate",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "Nomplate: Node template engine",
   "main": "index.js",
   "engines": {

--- a/src/builder.js
+++ b/src/builder.js
@@ -39,12 +39,22 @@ function processClassName(value) {
 
 function getUpdateScheduler(elem, handler) {
   return function _getUpdateScheduler(optCompleteHandler) {
-    if (elem.onRender) {
-      config().schedule(elem, () => {
+    if (elem.render) {
+      function renderNow() {
         /* eslint-disable no-use-before-define */
-        elem.onRender(builder, handler, optCompleteHandler);
+        elem.render(builder, handler, optCompleteHandler);
         /* eslint-enable no-use-before-define */
-      });
+      }
+
+      if (optCompleteHandler) {
+        // Ensure the complete handler is called by the scheduler, even if this
+        // element is descheduled because a parent was also rendered.
+        renderNow.onSkipped = function() {
+          optCompleteHandler(elem);
+        };
+      }
+
+      config().schedule(elem, renderNow);
     }
   };
 }

--- a/src/element.js
+++ b/src/element.js
@@ -25,7 +25,7 @@ class Element {
 
     // Handler that should be overridden by renderElement if there is an
     // updateable handler present.
-    this.onRender = null;
+    this.render = null;
     this.hasUpdateableHandler = false;
 
     // Append #text child if provided

--- a/src/operations.js
+++ b/src/operations.js
@@ -27,7 +27,7 @@ function setRenderFunction(getUpdateElement, nomElement, document) {
   return function _setRenderFunction(domElement) {
     if (nomElement.hasUpdateableHandler) {
       /* eslint-disable no-param-reassign */
-      nomElement.onRender = getUpdateElement(nomElement, document, domElement);
+      nomElement.render = getUpdateElement(nomElement, document, domElement);
       /* eslint-enable no-param-reassign */
     }
   };

--- a/test/render_element_test.js
+++ b/test/render_element_test.js
@@ -484,6 +484,55 @@ describe('Nomplate renderElement', () => {
         button.click();
       });
     });
+
+    describe('async update()', () => {
+      /**
+       * Bug #66 Two async handlers in a single container calling update
+       * will only render the first caller.
+       */
+      it.skip('mutates correct elements', (done) => {
+        // AND secondary onRender handlers that are provided to callers
+        // of update(), should always be called, even if they're discarded.
+        let state1 = 'abcd';
+        let state2 = null;
+        let updateHandlers = [];
+
+        const nomElements = dom.div({id: 'root'}, () => {
+          dom.div((update) => {
+            updateHandlers.push(update);
+
+            if (state1) {
+              dom.div({id: 'state1'}, state1);
+            }
+
+            if (state2) {
+              dom.div({id: 'state2'}, state2);
+            }
+          });
+        });
+
+        const root = renderElement(nomElements, doc);
+        console.log('FIRST RENDER', root.outerHTML);
+
+        updateHandlers[0](() => {
+          console.log('onRender');
+          state2 = 'efgh';
+          updateHandlers[0](() => {
+            done();
+          });
+        });
+
+        // updateHandlers[0](() => {
+          // console.log('outerHTML', root.outerHTML);
+          // console.log('textContent:', root.textContent);
+          // done();
+        // });
+
+        state2 = 'efgh';
+
+        console.log('element:', element.outerHTML);
+      });
+    });
   });
 });
 

--- a/test/render_element_test.js
+++ b/test/render_element_test.js
@@ -1,4 +1,5 @@
 const assert = require('chai').assert;
+const builder = require('../').builder;
 const config = require('../').config;
 const createWindow = require('../test_helper').createWindow;
 const dom = require('../').dom;
@@ -482,6 +483,39 @@ describe('Nomplate renderElement', () => {
         button.click();
         button.click();
         button.click();
+      });
+    });
+
+    describe('onRender handler', () => {
+      it('is called, even for skipped children', () => {
+        let updateRoot = null;
+        let updateChild1 = null;
+        let updateChild2 = null;
+
+        const root = dom.div({id: 'root'}, (update) => {
+          updateRoot = update;
+
+          dom.div({id: 'child1'}, (update) => {
+            updateChild1 = update;
+          });
+
+          dom.div({id: 'child2'}, (update) => {
+            updateChild2 = update;
+          });
+        });
+
+        const elem = renderElement(root, doc);
+        const rootRendered = sinon.spy();
+        const child1Rendered = sinon.spy();
+        const child2Rendered = sinon.spy();
+        updateRoot(rootRendered);
+        updateChild1(child1Rendered);
+        updateChild2(child2Rendered);
+        builder.forceUpdate();
+
+        assert.equal(rootRendered.callCount, 1);
+        assert.equal(child1Rendered.callCount, 1);
+        assert.equal(child2Rendered.callCount, 1);
       });
     });
 

--- a/test/render_element_test.js
+++ b/test/render_element_test.js
@@ -488,6 +488,12 @@ describe('Nomplate renderElement', () => {
 
     describe('onRender handler', () => {
       it('is called, even for skipped children', () => {
+        /**
+         * When calling the provided "update" function from a container block,
+         * one can provide a local function that will be called when the rendered.
+         * This ensures that we call your handler even if the actual element
+         * was skipped because a parent was rendered.
+         */
         let updateRoot = null;
         let updateChild1 = null;
         let updateChild2 = null;
@@ -564,7 +570,7 @@ describe('Nomplate renderElement', () => {
 
         state2 = 'efgh';
 
-        console.log('element:', element.outerHTML);
+        console.log('element:', root.outerHTML);
       });
     });
   });

--- a/test/scheduler_test.js
+++ b/test/scheduler_test.js
@@ -47,6 +47,20 @@ describe('Nomplate scheduler', () => {
     assert.equal(render.callCount, 1);
   });
 
+  it('calls completeHandler for skipped elements', () => {
+    const root = new Element('div');
+    const child = new Element('div');
+    const renderRoot = sinon.spy();
+    const renderChild = sinon.spy();
+    renderChild.onSkipped = sinon.spy();
+    child.parent = root;
+
+    schedule(root, renderRoot);
+    schedule(child, renderChild);
+    execute();
+    assert.equal(renderChild.onSkipped.callCount, 1);
+  });
+
   it('skips element children', () => {
     const root = new Element('ul');
     const rootRender = sinon.spy();

--- a/test/scheduler_test.js
+++ b/test/scheduler_test.js
@@ -27,6 +27,16 @@ describe('Nomplate scheduler', () => {
     assert.equal(render.callCount, 1);
   });
 
+  it('clears pending after render', () => {
+    const element = new Element('div');
+    const render = sinon.spy();
+    schedule(element, render);
+    execute();
+    assert.equal(render.callCount, 1);
+    execute();
+    assert.equal(render.callCount, 1);
+  });
+
   it('filters duplicates', () => {
     const root = new Element('div');
     const render = sinon.spy();


### PR DESCRIPTION
Even if the element was not rendered directly because a parent element was rendered instead.