### PR TITLE
Introduced support for dom.unsafe strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nomplate",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "description": "Nomplate: Node template engine",
   "main": "index.js",
   "engines": {

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -28,3 +28,4 @@ echo "Updated PATH with ${BASEDIR}/lib/nodejs/bin"
 # Add node_moduels/.bin to the path
 add_to_path "${BASEDIR}/node_modules/.bin"
 echo "Updated PATH with ${BASEDIR}/node_modules/.bin"
+

--- a/src/dom.js
+++ b/src/dom.js
@@ -55,4 +55,7 @@ dom.selector = builder.addSelector;
 // Helper for creating CSS @keyframes statements..
 dom.keyframes = builder.addKeyframe;
 
+// Helper to skip htmlEncode and support explicitly unsafe content.
+dom.unsafe = builder.unsafeContent;
+
 module.exports = dom;

--- a/src/html_encode.js
+++ b/src/html_encode.js
@@ -16,6 +16,11 @@ function getTextArea(document) {
  */
 function htmlEncode(str, optDocument) {
   const type = typeof str;
+  // Bail and return if we receive content like: {_isUnsafe: true, content: 'abcd'};
+  if (type === 'object' && str && str._isUnsafe && str.content) {
+    return str.content;
+  }
+
   if (type === 'number' || type === 'boolean') {
     return String(str);
   } else if (str === null || type === 'undefined' || !str.replace) {

--- a/src/render_string.js
+++ b/src/render_string.js
@@ -104,12 +104,11 @@ function renderString() {
       write('>');
     }
 
-    if (element.nodeName === 'style' && element.selectors.length > 0) {
+    if (element.nodeName === 'style' && element.selectors && element.selectors.length > 0) {
       write(element.renderSelectors());
     } else if (textValue) {
       write(htmlEncode(textValue));
     }
-
 
     if (children.length > 0) {
       writeCarriageReturn();

--- a/test/render_element_test.js
+++ b/test/render_element_test.js
@@ -11,7 +11,6 @@ describe('renderElement', () => {
     doc = createDocument();
   });
 
-
   describe('creation', () => {
     it('creates simple element', () => {
       const domElement = renderElement(dom.div(), doc);

--- a/test/render_string_test.js
+++ b/test/render_string_test.js
@@ -69,6 +69,16 @@ describe('Nomplate renderer dom', () => {
     assert.equal(render(elem), '<div class="&lt;" style="&gt;">&lt;script&gt;</div>');
   });
 
+  it('does not escape unsafe textContent', () => {
+    const elem = dom.div(dom.unsafe('<script>'));
+    assert.equal(render(elem), '<div><script></div>');
+  });
+
+  it('does not escape unsafe attribute values', () => {
+    const elem = dom.div({className: dom.unsafe('<script>'), id: dom.unsafe('<script>'), dataFoo: '<script>'});
+    assert.equal(render(elem), '<div class="<script>" id="<script>" data-foo="&lt;script&gt;"></div>');
+  });
+
   it('handls null text content', () => {
     const elem = dom.div({className: 'abcd'}, null);
     assert.equal(render(elem), '<div class="abcd"></div>');


### PR DESCRIPTION
Anywhere we html encode text (attributes and textValues), we can now wrap that text in dom.unsafe('abcd') to skip html encoding.

```JavaScript
dom.h1(dom.unsafe('This is a script tag: <script>'));
```